### PR TITLE
linear response in more than 1d

### DIFF
--- a/pymc_bart/tree.py
+++ b/pymc_bart/tree.py
@@ -201,7 +201,7 @@ class Tree:
         if self.idx_leaf_nodes is not None:
             for node_index in self.idx_leaf_nodes:
                 leaf_node = self.get_node(node_index)
-                output[leaf_node.idx_data_points] = leaf_node.value
+                output[leaf_node.idx_data_points] = leaf_node.value.squeeze()
         return output.T
 
     def predict(

--- a/tests/test_pgbart.py
+++ b/tests/test_pgbart.py
@@ -48,8 +48,8 @@ def test_fast_mean():
 @pytest.mark.parametrize(
     argnames="x,y,a_expected, b_expected",
     argvalues=[
-        (np.array([1, 2, 3, 4, 5]), np.array([1, 2, 3, 4, 5]), 0.0, 1.0),
-        (np.array([1, 2, 3, 4, 5]), np.array([1, 1, 1, 1, 1]), 1.0, 0.0),
+        (np.array([1, 2, 3, 4, 5]), np.array([[1, 2, 3, 4, 5]]), 0.0, 1.0),
+        (np.array([1, 2, 3, 4, 5]), np.array([[1, 1, 1, 1, 1]]), 1.0, 0.0),
     ],
     ids=["1d-id", "1d-const"],
 )
@@ -57,7 +57,9 @@ def test_fast_linear_fit(x, y, a_expected, b_expected):
     y_fit, linear_params = fast_linear_fit(x, y)
     assert linear_params[0] == a_expected
     assert linear_params[1] == b_expected
-    np.testing.assert_almost_equal(actual=y_fit, desired=a_expected + x * b_expected)
+    np.testing.assert_almost_equal(
+        actual=y_fit, desired=np.atleast_2d(a_expected + x * b_expected).T
+    )
 
 
 def test_discrete_uniform():


### PR DESCRIPTION
With these changes tests are passing locally, except for `test_missing_data[linear-response]` which fails randomly, no idea why. I did not have the time to test on real models.